### PR TITLE
Cleanup and fixing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,9 +76,11 @@ export USER_DSSI_DIR USER_LADSPA_DIR USER_LV2_DIR USER_VST2_DIR USER_VST3_DIR US
 # --------------------------------------------------------------
 # Targets
 
+ifneq ($(MOD_BUILD),true)
 all: libs plugins gen
-
-mod: MOD
+else
+all: MOD
+endif
 
 # --------------------------------------------------------------
 
@@ -86,12 +88,14 @@ submodules:
 	git submodule update --init --recursive
 
 libs:
-	$(MAKE) -C dpf/dgl ../build/libdgl-cairo.a
+ifeq ($(HAVE_CAIRO),true)
+	$(MAKE) -C dpf/dgl cairo
+endif
 
 plugins: libs
 	$(MAKE) all -C plugins/NeuralRecord
 
-MOD: clean
+MOD:
 	$(MAKE) mod -C plugins/NeuralRecord
 
 ifneq ($(CROSS_COMPILING),true)

--- a/plugins/NeuralRecord/MOD/manifest.ttl
+++ b/plugins/NeuralRecord/MOD/manifest.ttl
@@ -12,6 +12,6 @@
 <urn:brummer10:neuralrecord#preset001>
     a pset:Preset ;
     lv2:appliesTo <urn:brummer10:neuralrecord> ;
-    rdfs:label "" ;
+    rdfs:label "Default" ;
     rdfs:seeAlso <presets.ttl> .
 

--- a/plugins/NeuralRecord/MOD/modgui/icon-profiler.html
+++ b/plugins/NeuralRecord/MOD/modgui/icon-profiler.html
@@ -1,19 +1,16 @@
 <div class="mod-pedal profiler{{{cns}}}">
-    <div class="popup" mod-role="POPUP"></div>
+    <div class="popup"></div>
     <div class="background">
-
         <div mod-role="drag-handle" class="mod-drag-handle"></div>
         <div class="mod-plugin-name"><h1>{{label}}</h1></div>
         <div class="mod-control-group clearfix">
-            {{#controls.0}}
-            <div id="js-toggle" class="button" mod-role="input-control-port" mod-port-symbol="{{symbol}}" mod-widget="switch"></div>
-            {{/controls.0}}
+            <div id="js-toggle" class="button" mod-role="input-control-port" mod-port-symbol="PROFILE" mod-widget="switch"></div>
         </div>
             <div class="meterbar">
-                <div class="meter" mod-role="METER" mod-port-symbol="{{symbol}}"></div>
+                <div class="meter" mod-port-symbol="METER"></div>
             </div>
-            <div class="progressbar" title="{{comment}}">
-                <div class="progress" mod-role="STATE" mod-port-symbol="{{symbol}}"></div>
+            <div class="progressbar">
+                <div class="progress" mod-port-symbol="STATE"></div>
             </div>
         <div class="mod-pedal-input">
             {{#effect.ports.audio.input}}

--- a/plugins/NeuralRecord/MOD/modgui/script-profiler.js
+++ b/plugins/NeuralRecord/MOD/modgui/script-profiler.js
@@ -1,8 +1,8 @@
 function (event) {
 
-    const meter = event.icon.find ('[mod-role=METER]');
-    const state = event.icon.find ('[mod-role=STATE]');
-    const popup = event.icon.find ('[mod-role=POPUP]');
+    const meter = event.icon.find ('[mod-port-symbol=METER]');
+    const state = event.icon.find ('[mod-port-symbol=STATE]');
+    const popup = event.icon.find ('.popup');
 
     var position = "0";
 

--- a/plugins/NeuralRecord/Makefile
+++ b/plugins/NeuralRecord/Makefile
@@ -34,7 +34,8 @@ FILES_UI = \
 UI_TYPE = cairo
 include ../../dpf/Makefile.plugins.mk
 
-BUILD_CXX_FLAGS += -pthread `pkg-config --cflags sndfile`  `pkg-config --libs sndfile`
+BUILD_CXX_FLAGS += -pthread $(shell $(PKG_CONFIG) --cflags sndfile)
+LINK_FLAGS += -pthread $(shell $(PKG_CONFIG) --libs sndfile)
 
 # --------------------------------------------------------------
 # Enable all selected plugin types

--- a/plugins/NeuralRecord/PluginNeuralCapture.hpp
+++ b/plugins/NeuralRecord/PluginNeuralCapture.hpp
@@ -134,6 +134,8 @@ struct Preset {
 
 const Preset factoryPresets[] = {
     {
+        "Default",
+        { 0.f, 0.f, 0.f, 0.f }
     }
     //,{
     //    "Another preset",  // preset name

--- a/plugins/NeuralRecord/profiler.cc
+++ b/plugins/NeuralRecord/profiler.cc
@@ -245,7 +245,7 @@ inline std::string Profil::get_path() {
     std::string pPath;
 
 #ifndef  __MOD_DEVICES__
-#if defined(WIN32) || defined(_WIN32)
+#ifdef _WIN32
     pPath = getenv("USERPROFILE");
     if (pPath.empty()) {
         pPath = getenv("HOMEDRIVE");
@@ -254,15 +254,16 @@ inline std::string Profil::get_path() {
 #else
     pPath = getenv("HOME");
 #endif
-    pPath +=PATH_SEPARATOR;
-    pPath +="profiles";
-    pPath +=PATH_SEPARATOR;
-
+    pPath += PATH_SEPARATOR "profiles" PATH_SEPARATOR;
 #else
-    pPath = "/data/user-files/Audio Recordings/profiles/";
+    if (const char* const userFilesDir = std::getenv("MOD_USER_FILES_DIR"))
+        pPath = userFilesDir;
+    else
+        pPath = "/data/user-files";
+    pPath += PATH_SEPARATOR "Audio Recordings" PATH_SEPARATOR "profiles" PATH_SEPARATOR;
 #endif
     if (!(stat(pPath.c_str(), &sb) == 0 && S_ISDIR(sb.st_mode))) {
-#if defined(WIN32) || defined(_WIN32)
+#ifdef _WIN32
         mkdir(pPath.c_str());
 #else
         mkdir(pPath.c_str(), S_IRWXU | S_IRWXG | S_IROTH | S_IXOTH);
@@ -282,10 +283,7 @@ inline std::string Profil::get_ifilename() {
     struct stat sb;
     char * path = strdup(get_profile_library_path().data());
     std::string iname = dirname(path);
-    iname += PATH_SEPARATOR;
-    iname += "resources";
-    iname += PATH_SEPARATOR;
-    iname += "input.wav";
+    iname += PATH_SEPARATOR "resources" PATH_SEPARATOR "input.wav";
     std::string oname = get_path() + "input.wav";
     if (stat (oname.c_str(), &sb) != 0 && stat (iname.c_str(), &sb) == 0) {
         std::ifstream src(iname.c_str(), std::ios::binary);


### PR DESCRIPTION
- `MOD_BUILD` can be used to detect builds of type `make moddwarf` (hint you can also do `make modpush` afterwards)
- `HAVE_CAIRO` is used to check if we should build DGL, skipping it in case it is not available (builds plugins without UI)
- Some little details on html/js were incorrect
- 1st factory preset was empty
- windows builds only need to check for `_WIN32` which is always present, no need to use any other macros
- mod builds assumed `/data/user-files/` dir, which is not true if running as part of mod-app
