### PR TITLE
Small patches (Samplerate, error handling)

### DIFF
--- a/plugins/NeuralRecord/PluginNeuralCapture.cpp
+++ b/plugins/NeuralRecord/PluginNeuralCapture.cpp
@@ -95,6 +95,7 @@ void PluginNeuralCapture::initProgramName(uint32_t index, String& programName) {
 */
 void PluginNeuralCapture::sampleRateChanged(double newSampleRate) {
     fSampleRate = newSampleRate;
+    profil->set_samplerate(newSampleRate, profil); // init the DSP class
 }
 
 /**

--- a/plugins/NeuralRecord/UINeuralCapture.cpp
+++ b/plugins/NeuralRecord/UINeuralCapture.cpp
@@ -82,6 +82,8 @@ void UINeuralCapture::parameterChanged(uint32_t index, float value) {
                 fToolTip->setLabel("Error: Sample Rate mismatch, please use 48kHz");
             else if ((int)value == 4) 
                 fToolTip->setLabel(inputFile.c_str());
+            else if ((int)value == 5) 
+                fToolTip->setLabel("Error: Output timing does not match, deleting result.wav");
 
             break;
     }

--- a/plugins/NeuralRecord/profiler.cc
+++ b/plugins/NeuralRecord/profiler.cc
@@ -433,6 +433,8 @@ void Profil::disc_stream() {
         close_stream(&recfile);
         filesize = 0;
         if (!time_match) {
+            errors = 5.0;
+            setOutputParameterValue(ERRORS, errors);
             std::remove(outputfile.c_str());
         }
     }


### PR DESCRIPTION
Add setSampleRate for profil in sampleRateChanged to fix samplerate mismatches (like saving out the input.wav)

Added additional error when time_match fails